### PR TITLE
#115 Only convert array into SplFixedArray if PHP >= 5.3 is available

### DIFF
--- a/laterpay/vendor/Browscap.php
+++ b/laterpay/vendor/Browscap.php
@@ -584,7 +584,7 @@ class Browscap
 
         if ( version_compare(PHP_VERSION, '5.3.0', '>=') ) {
             // convert to SplFixedArray (requires less memory)
-            $tmp_user_agents    = SplFixedArray::fromArray($tmp_user_agents);
+            $tmp_user_agents        = SplFixedArray::fromArray($tmp_user_agents);
             $tmp_user_agents_count  = $tmp_user_agents->count();
         } else {
             $tmp_user_agents_count = count($tmp_user_agents);


### PR DESCRIPTION
@mturalenka please review and merge

The step where Browscap converts a regular array into a SplFixedArray for performance reasons is the only thing currently incompatible with PHP 5.2.
