### PR TITLE
added fix for attachment-pages to save teaser-content and pricing #374

### DIFF
--- a/laterpay/application/Controller/Admin/Post/Metabox.php
+++ b/laterpay/application/Controller/Admin/Post/Metabox.php
@@ -158,9 +158,42 @@ class LaterPay_Controller_Admin_Post_Metabox extends LaterPay_Controller_Abstrac
     }
 
     /**
+     * Checks the permissions on saving the metaboxes
+     *
+     * @param int $post_id
+     *
+     * @return bool true|false
+     */
+    protected function has_permission( $post_id ){
+
+        // autosave -> do nothing
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return false;
+        }
+
+        // Ajax -> do nothing
+        if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+            return false;
+        }
+
+        // no post found -> do nothing
+        $post = get_post( $post_id );
+        if ( $post === null ) {
+            return false;
+        }
+
+        // check if the current post type is enabled
+        if ( ! in_array( $post->post_type, $this->config->get( 'content.enabled_post_types' ) ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Save teaser content.
      *
-     * @wp-hook save_post
+     * @wp-hook save_post, edit_attachment
      *
      * @param int $post_id
      *
@@ -173,19 +206,7 @@ class LaterPay_Controller_Admin_Post_Metabox extends LaterPay_Controller_Abstrac
             return;
         }
 
-        // autosave -> do nothing
-        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-            return;
-        }
-
-        // Ajax -> do nothing
-        if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-            return;
-        }
-
-        // no post found -> do nothing
-        $post = get_post( $post_id );
-        if ( $post === null ) {
+        if ( ! $this->has_permission( $post_id ) ) {
             return;
         }
 
@@ -330,7 +351,7 @@ class LaterPay_Controller_Admin_Post_Metabox extends LaterPay_Controller_Abstrac
     /**
      * Save pricing of post.
      *
-     * @wp-hook save_post
+     * @wp-hook save_post, edit_attachments
      *
      * @param int $post_id
      *
@@ -347,13 +368,7 @@ class LaterPay_Controller_Admin_Post_Metabox extends LaterPay_Controller_Abstrac
             return;
         }
 
-        // autosave -> do nothing
-        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-            return;
-        }
-
-        // Ajax -> do nothing
-        if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+        if ( ! $this->has_permission( $post_id ) ) {
             return;
         }
 

--- a/laterpay/application/Core/Bootstrap.php
+++ b/laterpay/application/Core/Bootstrap.php
@@ -93,8 +93,11 @@ class LaterPay_Core_Bootstrap
 
             // save the teaser
             add_action( 'save_post',                        array( $post_metabox_controller, 'save_teaser_content_box' ) );
+            add_action( 'edit_attachment',                  array( $post_metabox_controller, 'save_teaser_content_box' ) );
+
             // save the pricing
             add_action( 'save_post',                        array( $post_metabox_controller, 'save_post_pricing_form') );
+            add_action( 'edit_attachment',                  array( $post_metabox_controller, 'save_post_pricing_form') );
 
             // load scripts for the admin pages
             add_action( 'admin_print_styles-post.php',      array( $post_metabox_controller, 'load_assets' ) );


### PR DESCRIPTION
added the missing "edit_attachment"-Hook for saving attachment pages.
