### PR TITLE
Fix click delegation logic

### DIFF
--- a/laterpay/assets/js_src/laterpay-post-view.js
+++ b/laterpay/assets/js_src/laterpay-post-view.js
@@ -215,25 +215,23 @@ YUI().use('node', 'laterpay-dialog', 'laterpay-iframe', 'laterpay-easyxdm', func
                           },
         dm              = new Y.LaterPay.DialogManager();
 
-    if (!$purchaseLink) {
-        // don't register the dialogs, if there's no purchase link in the page
-        return;
-    }
-
-    if ($purchaseLink.getData('preview-as-visitor')) {
-        // bind event to purchase link and return, if 'preview as visitor' is activated for admins
-        Y.one(Y.config.doc).delegate(
-            'click',
-            function(event) {
-                event.preventDefault();
+    // bind event to purchase link and if 'preview as visitor' is activated for admins handle it accordingly
+    Y.one(Y.config.doc).delegate(
+        'click',
+        function(event) {
+            event.preventDefault();
+            if (event.currentTarget.getData('preview-as-visitor')) {    
                 alert(lpVars.i18nAlert);
-            },
-            '.lp_js_do-purchase'
-        );
-
-        return;
-    }
-
-    dm.attachToLinks('.lp_js_do-purchase', ppuContext.showCloseBtn);
-
+            }
+            else {
+                var url = event.currentTarget.getAttribute('href');
+                if (event.currentTarget.hasAttribute('data-laterpay')) {
+                    url = event.currentTarget.getAttribute('data-laterpay');
+                }
+                dm.openDialog(url, ppuContext.showCloseBtn);
+            }
+        },
+        '.lp_js_do-purchase'
+    );
 });
+


### PR DESCRIPTION
Make sure that we always delegate the click event even if there is no
purchase link on the page currently. We then don't call attachToLinks
anymore, as we want to check whether we're in preview mode before
we call LaterPay's DialogManager.

@drdla: Please check that my changes now reflect the desired behavior. The initial problem was that the old code `return`ed when there was no $purchaseLink to be found, which of course happened if there was no post loaded (because we load them via ajax). Therefor `dm.attachToLinks` was never called. Also, the preview mode delegation never worked, because that also relied on $purchaseLink being `truish`. I now sidestep `dm.attachToLinks` completely and always attach a delegate event handler for `.lp_js_do-purchase`.
