### PR TITLE
added 'the_post'-action to ajax_load_purchased_content

### DIFF
--- a/laterpay/application/Controller/Post.php
+++ b/laterpay/application/Controller/Post.php
@@ -46,6 +46,9 @@ class LaterPay_Controller_Post extends LaterPay_Controller_Abstract
             exit;
         }
 
+        // call 'the_post'-hook to enable modification of loaded data by themes and plugins
+        do_action_ref_array( 'the_post', array( &$post ) );
+
         $content = apply_filters( 'the_content', $post->post_content );
         $content = str_replace( ']]>', ']]&gt;', $content );
 


### PR DESCRIPTION
Allow modifications to be made after the post has been loaded from the database. It is called by default in the setup_postdata function, which is invoked for every post during the_loop, to setup the global $post-variable.
