### PR TITLE
Feature/551 force language of account links

### DIFF
--- a/laterpay/application/Controller/Account.php
+++ b/laterpay/application/Controller/Account.php
@@ -35,6 +35,11 @@ class LaterPay_Controller_Account extends LaterPay_Controller_Abstract
             $show = 'lg';
         }
 
+        if ( empty( $forcelang ) ) {
+            // render account links in the language of the blog by default
+            $forcelang = substr( get_locale(), 0, 2 );
+        }
+
         // create account links URL with passed params
         $client_options = LaterPay_Helper_Config::get_php_client_options();
         $client = new LaterPay_Client(

--- a/laterpay/application/Controller/Shortcode.php
+++ b/laterpay/application/Controller/Shortcode.php
@@ -545,7 +545,7 @@ class LaterPay_Controller_Shortcode extends LaterPay_Controller_Abstract
             $access       = LaterPay_Helper_Post::has_purchased_gift_card();
             $landing_page = get_option( 'laterpay_landing_page');
 
-            // add gift codes with urls to passes
+            // add gift codes with URLs to passes
             $passes       = $this->add_free_codes_to_passes( $passes, $_GET[ 'link'] );
             $view_args = array(
                 'gift_code'               => is_array( $access ) ? $access['code'] : null,
@@ -619,7 +619,7 @@ class LaterPay_Controller_Shortcode extends LaterPay_Controller_Abstract
             'show'      => 'lg', // render the login / logout link with greeting by default
             'css'       => $this->config->get( 'css_url' ) . 'laterpay-account-links.css',
             'next'      => is_singular() ? get_permalink() : home_url(),
-            'forcelang' => null,
+            'forcelang' => substr( get_locale(), 0, 2 ), // render account links in language of the blog by default
         ), $atts );
 
         $view_args = array(

--- a/laterpay/application/Controller/Shortcode.php
+++ b/laterpay/application/Controller/Shortcode.php
@@ -619,7 +619,7 @@ class LaterPay_Controller_Shortcode extends LaterPay_Controller_Abstract
             'show'      => 'lg', // render the login / logout link with greeting by default
             'css'       => $this->config->get( 'css_url' ) . 'laterpay-account-links.css',
             'next'      => is_singular() ? get_permalink() : home_url(),
-            'forcelang' => substr( get_locale(), 0, 2 ), // render account links in language of the blog by default
+            'forcelang' => substr( get_locale(), 0, 2 ), // render account links in the language of the blog by default
         ), $atts );
 
         $view_args = array(


### PR DESCRIPTION
@AliaksandrVahura-ScienceSoft please review and merge

btw: why do we have defaults in the function definition and set values if it's empty directly afterwards? https://github.com/laterpay/laterpay-wordpress-plugin/compare/feature/551_force_language_of_account_links?expand=1#diff-873977fbfe0208553a226a29e06dd91dR18

Is there a good reason that I am not aware of or is this a duplication?