### PR TITLE
#647. Price / revenue model column and pricing widget is missing on post overview.

### DIFF
--- a/laterpay/application/Controller/Install.php
+++ b/laterpay/application/Controller/Install.php
@@ -379,7 +379,7 @@ class LaterPay_Controller_Install extends LaterPay_Controller_Abstract
             return;
         }
 
-        if ( get_option( 'laterpay_is_in_visible_test_mode' ) === null ) {
+        if ( get_option( 'laterpay_is_in_visible_test_mode' ) === false ) {
             add_option( 'laterpay_is_in_visible_test_mode', 0 );
         }
     }

--- a/laterpay/application/Core/Bootstrap.php
+++ b/laterpay/application/Core/Bootstrap.php
@@ -134,7 +134,7 @@ class LaterPay_Core_Bootstrap
             add_action( 'add_meta_boxes',                   array( $post_metabox_controller, 'add_meta_boxes' ) );
 
             // save LaterPay post data. If only time pass purchases are allowed, then pricing information need not be saved.
-            if ( get_option( 'laterpay_only_time_pass_purchases_allowed' ) === true ) {
+            if ( get_option( 'laterpay_only_time_pass_purchases_allowed' ) ) {
                 add_action( 'save_post',                    array( $post_metabox_controller, 'save_laterpay_post_data_without_pricing' ) );
                 add_action( 'edit_attachment',              array( $post_metabox_controller, 'save_laterpay_post_data_without_pricing' ) );
             } else {
@@ -154,7 +154,7 @@ class LaterPay_Core_Bootstrap
             add_action( 'wp_ajax_laterpay_remove_post_dynamic_pricing', array( $post_metabox_controller, 'remove_dynamic_pricing_data' ) );
 
             // setup custom columns for each allowed post_type, if allowed purchases aren't restricted to time passes
-            if ( get_option( 'laterpay_only_time_pass_purchases_allowed' ) === false ) {
+            if ( ! get_option( 'laterpay_only_time_pass_purchases_allowed' ) ) {
                 $column_controller = new LaterPay_Controller_Admin_Post_Column( $this->config );
                 foreach ( $this->config->get( 'content.enabled_post_types' ) as $post_type ) {
                     add_filter( 'manage_' . $post_type . '_posts_columns',         array( $column_controller, 'add_columns_to_posts_table' ) );

--- a/laterpay/views/backend/pricing.php
+++ b/laterpay/views/backend/pricing.php
@@ -33,7 +33,7 @@
                                name="only_time_pass_purchase_mode"
                                class="lp_js_onlyTimePassPurchaseModeInput lp_toggle_input"
                                value="1"
-                               <?php if ( $laterpay['only_time_pass_purchases_allowed'] === true ) { echo 'checked'; } ?>
+                               <?php if ( $laterpay['only_time_pass_purchases_allowed'] ) { echo 'checked'; } ?>
                         >
                         <span class="lp_toggle_text"></span>
                         <span class="lp_toggle_handle"></span>
@@ -43,7 +43,7 @@
             <?php _e( '<strong>only time pass purchases.</strong>', 'laterpay' ); ?>
         </div>
 
-        <?php if ( $laterpay['only_time_pass_purchases_allowed'] === true ) : ?>
+        <?php if ( $laterpay['only_time_pass_purchases_allowed'] ) : ?>
             <ul class="lp_js_hideInTimePassOnlyMode lp_row lp_u_clearfix" style="display:none;">
         <?php else : ?>
             <ul class="lp_js_hideInTimePassOnlyMode lp_row lp_u_clearfix">


### PR DESCRIPTION
Removed comparisons for laterpay_only_time_pass_purchases_allowed option.