### PR TITLE
Heroku & CloudFlare Universal SSL / flexible SSL

### DIFF
--- a/laterpay/application/Helper/Request.php
+++ b/laterpay/application/Helper/Request.php
@@ -25,6 +25,10 @@ class LaterPay_Helper_Request {
      */
     public static function get_current_url() {
         $ssl = isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] == 'on';
+        // Check for Cloudflare Universal SSL / flexible SSL
+        if ( isset( $_SERVER['HTTP_CF_VISITOR'] ) && strpos( $_SERVER['HTTP_CF_VISITOR'], 'https' ) !== false ) {
+            $ssl = true;
+        }
         $uri = $_SERVER['REQUEST_URI'];
 
         // process Ajax requests

--- a/laterpay/application/Helper/Request.php
+++ b/laterpay/application/Helper/Request.php
@@ -56,14 +56,21 @@ class LaterPay_Helper_Request {
         } else {
             $pageURL = 'http://';
         }
+        $serverPort = $_SERVER['SERVER_PORT'];
         $serverName = $_SERVER['SERVER_NAME'];
         if ( $serverName == 'localhost' and function_exists('site_url')) {
-           $serverName = (str_replace(array('http://', 'https://'), '', site_url())) ; // WP function 
+            $serverName = (str_replace(array('http://', 'https://'), '', site_url())) ; // WP function 
+            // overwrite port on Heroku 
+            if ( isset( $_SERVER['HTTP_CF_VISITOR'] ) && strpos( $_SERVER['HTTP_CF_VISITOR'], 'https' ) !== false ) {
+                $serverPort = 443;
+            } else {
+                $serverPort = 80;
+            }
         }
-        if ( ! $ssl && $_SERVER['SERVER_PORT'] != '80' ) {
-            $pageURL .= $serverName . ':' . $_SERVER['SERVER_PORT'] . $uri;
-        } else if ( $ssl && $_SERVER['SERVER_PORT'] != '443' ) {
-            $pageURL .= $serverName . ':' . $_SERVER['SERVER_PORT'] . $uri;
+        if ( ! $ssl && $serverPort != '80' ) {
+            $pageURL .= $serverName . ':' . $serverPort . $uri;
+        } else if ( $ssl && $serverPort != '443' ) {
+            $pageURL .= $serverName . ':' . $serverPort . $uri;
         } else {
             $pageURL .= $serverName . $uri;
         }

--- a/laterpay/application/Helper/Request.php
+++ b/laterpay/application/Helper/Request.php
@@ -52,12 +52,16 @@ class LaterPay_Helper_Request {
         } else {
             $pageURL = 'http://';
         }
+        $serverName = $_SERVER['SERVER_NAME'];
+        if ( $serverName == 'localhost' and function_exists('site_url')) {
+           $serverName = (str_replace(array('http://', 'https://'), '', site_url())) ; // WP function 
+        }
         if ( ! $ssl && $_SERVER['SERVER_PORT'] != '80' ) {
-            $pageURL .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $uri;
+            $pageURL .= $serverName . ':' . $_SERVER['SERVER_PORT'] . $uri;
         } else if ( $ssl && $_SERVER['SERVER_PORT'] != '443' ) {
-            $pageURL .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $uri;
+            $pageURL .= $serverName . ':' . $_SERVER['SERVER_PORT'] . $uri;
         } else {
-            $pageURL .= $_SERVER['SERVER_NAME'] . $uri;
+            $pageURL .= $serverName . $uri;
         }
 
         return $pageURL;


### PR DESCRIPTION
Extend get_current_url() for Heroku & CloudFlare flexible SSL.

Avoid "localhost" on Heroku (and other cloud hosting platforms). Detect if used within WordPress. 
Correct handling of server port. 

Tested in sandbox mode on Heroku with and without CloudFlare Universal/flexible SSL.
(Without this fix, it's not possible to use laterpay wordpress plugin on heroku).

Closes https://github.com/laterpay/laterpay-wordpress-plugin/issues/693 

Basically the same patch /  pull request as for the laterpay-client submodule.