### PR TITLE
Added wp-ffpc to known page caching plugins.

### DIFF
--- a/laterpay/application/Helper/Cache.php
+++ b/laterpay/application/Helper/Cache.php
@@ -62,6 +62,7 @@ class LaterPay_Helper_Cache
             'hyper-cache/plugin.php',               // Hyper Cache
             'hyper-cache-extended/plugin.php',      // Hyper Cache Extended
             'really-static/main.php',               // Really Static
+            'wp-ffpc/wp-ffpc.php',                  // WP-FFPC
         );
 
         foreach ( $caching_plugins as $plugin ) {


### PR DESCRIPTION
Help the installer to set laterpay_caching_compatibility when wp-ffpc is detected.

wp-ffpc can be found here: https://wordpress.org/plugins/wp-ffpc/