### PR TITLE
Fixed conditions for automatic or manual rendering of purchase button

### DIFF
--- a/laterpay/application/Controller/Install.php
+++ b/laterpay/application/Controller/Install.php
@@ -664,7 +664,6 @@ class LaterPay_Controller_Install extends LaterPay_Controller_Abstract
         add_option( 'laterpay_api_merchant_backend_url',                'https://merchant.laterpay.net/' );
         add_option( 'laterpay_access_logging_enabled',                  1 );
         add_option( 'laterpay_caching_compatibility',                   (bool) LaterPay_Helper_Cache::site_uses_page_caching() );
-        add_option( 'laterpay_show_purchase_button',                    1 );
         add_option( 'laterpay_teaser_content_word_count',               '60' );
         add_option( 'laterpay_preview_excerpt_percentage_of_content',   '25' );
         add_option( 'laterpay_preview_excerpt_word_count_min',          '26' );

--- a/laterpay/application/Controller/Post.php
+++ b/laterpay/application/Controller/Post.php
@@ -666,7 +666,7 @@ class LaterPay_Controller_Post extends LaterPay_Controller_Abstract
 
     /**
      * Callback to generate a LaterPay purchase button within the theme that can be freely positioned.
-     * When doing this, you should set config option 'content.show_purchase_button' to FALSE to disable the default
+     * When doing this, you should set config option 'laterpay_purchase_button_positioned_manually' to TRUE to disable the default
      * rendering of a purchase button at the beginning of the post content, thus avoiding multiple purchase buttons
      * on the post page.
      *
@@ -1001,9 +1001,9 @@ class LaterPay_Controller_Post extends LaterPay_Controller_Abstract
             return $content;
         }
 
-        // add a purchase button as very first element of the content
-        if ( (bool) $this->config->get( 'content.show_purchase_button' ) ) {
-            $html .= '<div class="lp_clearfix lp_relative lp_mt lp_mb+">';
+        // add the purchase button as very first element of the content, if it is not positioned manually
+        if ( (bool) get_option( 'laterpay_purchase_button_positioned_manually' ) == false ) {
+            $html .= '<div class="lp_purchase-button-wrapper">';
             $html .= LaterPay_Helper_View::remove_extra_spaces( $this->get_text_view( 'frontend/partials/post/purchase_button' ) );
             $html .= '</div>';
         }

--- a/laterpay/asset_sources/scss/components/_purchase_button.scss
+++ b/laterpay/asset_sources/scss/components/_purchase_button.scss
@@ -90,6 +90,13 @@
     }
 }
 
+// wrapper used to set the purchase button apart from the post content when positioned automatically
+.lp_purchase-button-wrapper {
+    @extend %clearfix;
+
+    margin: $fs 0 $fs--2 !important;
+}
+
 
 // Responsiveness ------------------------------------------------------------------------------------------------------
 @media (max-width:567px) {

--- a/laterpay/asset_sources/scss/objects/_utilities.scss
+++ b/laterpay/asset_sources/scss/objects/_utilities.scss
@@ -63,11 +63,11 @@
  */
 %clearfix:before,
 %clearfix:after {
-    content: ' '; /* 1 */
-    display: table; /* 2 */
+    content: ' ' !important; /* 1 */
+    display: table !important; /* 2 */
 }
 %clearfix:after {
-    clear: both;
+    clear: both !important;
 }
 
 // helper class for clearfix

--- a/laterpay/laterpay.php
+++ b/laterpay/laterpay.php
@@ -189,7 +189,6 @@ function laterpay_get_plugin_config() {
         'content.preview_percentage_of_content'             => get_option( 'laterpay_preview_excerpt_percentage_of_content' ),
         'content.preview_word_count_min'                    => get_option( 'laterpay_preview_excerpt_word_count_min' ),
         'content.preview_word_count_max'                    => get_option( 'laterpay_preview_excerpt_word_count_max' ),
-        'content.show_purchase_button'                      => get_option( 'laterpay_show_purchase_button' ),
         'content.enabled_post_types'                        => $enabled_post_types ? $enabled_post_types : array(),
     );
     $config->import( $content_settings );

--- a/laterpay/uninstall.php
+++ b/laterpay/uninstall.php
@@ -76,8 +76,6 @@ delete_option( 'laterpay_preview_excerpt_percentage_of_content' );
 delete_option( 'laterpay_preview_excerpt_word_count_min' );
 delete_option( 'laterpay_preview_excerpt_word_count_max' );
 
-delete_option( 'laterpay_show_purchase_button' );
-
 delete_option( 'laterpay_unlimited_access' );
 
 delete_option( 'laterpay_bulk_operations' );

--- a/laterpay/views/frontend/partials/widget/purchase_button.php
+++ b/laterpay/views/frontend/partials/widget/purchase_button.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * We can't use line-breaks in this template, otherwise wpautop() would add <br> before every attribute
  */
 
-if ( $laterpay_widget['purchase_button_is_hidden'] ) : ?>
+if ( $laterpay_widget['purchase_button_is_hidden'] ): ?>
     <div>&nbsp;</div>
 <?php
     return;
@@ -26,7 +26,7 @@ $args = array(
     'data-laterpay'                 => $laterpay_widget['link'],
     'data-post-id'                  => $laterpay_widget['post_id'],
     'data-preview-as-visitor'       => $laterpay_widget['preview_post_as_visitor'],
-    'data-is-in-visible-test-mode' => $laterpay_widget['is_in_visible_test_mode'],
+    'data-is-in-visible-test-mode'  => $laterpay_widget['is_in_visible_test_mode'],
 );
 $arg_str = '';
 foreach ( $args as $key => $value ) {
@@ -42,6 +42,6 @@ $title = sprintf(
 
 <a <?php echo $arg_str; ?>><?php echo $title; ?></a>
 
-<?php if ( isset( $laterpay['show_post_ratings'] ) && $laterpay['show_post_ratings'] ) : ?>
+<?php if ( isset( $laterpay['show_post_ratings'] ) && $laterpay['show_post_ratings'] ): ?>
     <div id="lp_js_postRatingPlaceholder"></div>
 <?php endif; ?>


### PR DESCRIPTION
@AliaksandrVahura-ScienceSoft please review and merge.

The rendering of manually positioned purchase buttons was broken and it seems we had a leftover of the old config model in there, which I fixed.
I tested this fix and everything worked well, but please double-check that I did not break anything else with my changes.