### PR TITLE
PHPCS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,6 @@ jobs:
 
       # run tests!
       # - run: phpunit
+
+      - run: composer run-script wpcs
+      - run: composer run-script phpcs

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laterpay/laterpay-client-php": "dev-develop"
     },
     "require-dev": {
-        "wp-coding-standards/wpcs": "dev-develop#9c4de8175ce1f82813f8c9c8f11809ee6c794efc"
+        "wp-coding-standards/wpcs": "0.14.1"
     },
     "scripts": {
         "post-install-cmd": "find laterpay/vendor/ -type d -name \".git\" | xargs rm -rf",

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -37,4 +37,20 @@
     <rule ref="WordPress.Variables.GlobalVariables">
         <severity>0</severity>
     </rule>
+
+	<!-- Exclude ALL THE (cosmetic) THINGS until we pass, then let's iteratively remove exclusions and fix things chunk by chunk -->
+	<rule ref="WordPress">
+		<exclude name="Generic.Classes.OpeningBraceSameLine"/>
+		<exclude name="Generic.Files.EndFileNewline.NotFound"/>
+		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration"/>
+		<exclude name="Squiz"/>
+		<exclude name="WordPress.Arrays"/>
+		<exclude name="WordPress.Files.FileName"/>
+		<exclude name="WordPress.Functions.FunctionCallSignatureNoParams.WhitespaceFound"/>
+		<exclude name="WordPress.NamingConventions"/>
+		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
+		<exclude name="WordPress.WP.I18n.UnorderedPlaceholdersText"/>
+		<exclude name="WordPress.WhiteSpace"/>
+	</rule>
 </ruleset>


### PR DESCRIPTION
This excludes vast swathes of (what I believe are) basically cosmetic issues for the sake of getting *something* passing quickly and reducing chance of regression - we can then iteratively trim down the exclusion list and fix things as we go, until the Glorious End Goal (probably) of no exclusions at all

This still fails because of more concerning issues like `WordPress.VIP.ValidatedSanitizedInput.MissingUnslash` and `WordPress.XSS.EscapeOutput.OutputNotEscaped`, but that's a *much* smaller and more manageable set!

Let's try to get this passing and merged please?