### PR TITLE
PHPCS with ALL the exclusions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,6 @@ jobs:
 
       # run tests!
       # - run: phpunit
+
+      - run: composer run-script wpcs
+      - run: composer run-script phpcs

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laterpay/laterpay-client-php": "dev-develop"
     },
     "require-dev": {
-        "wp-coding-standards/wpcs": "dev-develop#9c4de8175ce1f82813f8c9c8f11809ee6c794efc"
+        "wp-coding-standards/wpcs": "0.14.1"
     },
     "scripts": {
         "post-install-cmd": "find laterpay/vendor/ -type d -name \".git\" | xargs rm -rf",

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -37,4 +37,20 @@
     <rule ref="WordPress.Variables.GlobalVariables">
         <severity>0</severity>
     </rule>
+
+	<!-- Exclude ALL THE (cosmetic) THINGS until we pass, then let's iteratively remove exclusions and fix things chunk by chunk -->
+	<rule ref="WordPress">
+		<exclude name="Generic.Classes.OpeningBraceSameLine"/>
+		<exclude name="Generic.Files.EndFileNewline.NotFound"/>
+		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration"/>
+		<exclude name="Squiz"/>
+		<exclude name="WordPress.Arrays"/>
+		<exclude name="WordPress.Files.FileName"/>
+		<exclude name="WordPress.Functions.FunctionCallSignatureNoParams.WhitespaceFound"/>
+		<exclude name="WordPress.NamingConventions"/>
+		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
+		<exclude name="WordPress.WP.I18n.UnorderedPlaceholdersText"/>
+		<exclude name="WordPress.WhiteSpace"/>
+	</rule>
 </ruleset>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -38,8 +38,24 @@
         <severity>0</severity>
     </rule>
 
-	<!-- Exclude ALL THE (cosmetic) THINGS until we pass, then let's iteratively remove exclusions and fix things chunk by chunk -->
+	<!-- Exclude ALL THE THINGS until we pass, then let's iteratively remove exclusions and fix things chunk by chunk -->
 	<rule ref="WordPress">
+		<!-- Exclusions we should drop ASAP, just here to get a passing test run -->
+		<exclude name="PSR2.Files.ClosingTag.NotAllowed"/>
+		<exclude name="PSR2.Methods.MethodDeclaration.FinalAfterVisibility"/>
+		<exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification"/>
+		<exclude name="WordPress.Functions.DontExtract.extract_extract"/>
+		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page_posts_per_page"/>
+		<exclude name="WordPress.VIP.RestrictedFunctions.get_page_by_title_get_page_by_title"/>
+		<exclude name="WordPress.VIP.RestrictedFunctions.user_meta_get_user_meta"/>
+		<exclude name="WordPress.VIP.RestrictedFunctions.user_meta_update_user_meta"/>
+		<exclude name="WordPress.VIP.RestrictedVariables.user_meta__wpdb__usermeta"/>
+		<exclude name="WordPress.VIP.ValidatedSanitizedInput"/>
+		<exclude name="WordPress.WP.DeprecatedFunctions.like_escapeFound"/>
+		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText"/>
+		<exclude name="WordPress.WP.PreparedSQL.NotPrepared"/>
+		<exclude name="WordPress.XSS.EscapeOutput.OutputNotEscaped"/>
+		<!-- Relatively cosmetic exclusions - important to fix, but less urgent than the above -->
 		<exclude name="Generic.Classes.OpeningBraceSameLine"/>
 		<exclude name="Generic.Files.EndFileNewline.NotFound"/>
 		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>


### PR DESCRIPTION
I see it as better to have phpcs running and passing with a long list of
exclusions (that we can iteratively remove) than not running at all - at
least then we've constrained things to (approximately) only get better,
and we can remove exclusions one by one as we improve