### PR TITLE
Add info messages if account setup is not done.

### DIFF
--- a/laterpay/application/Controller/Admin.php
+++ b/laterpay/application/Controller/Admin.php
@@ -64,7 +64,11 @@ class LaterPay_Controller_Admin extends LaterPay_Controller_Base
      * @return void
      */
     public function add_to_admin_panel() {
-        $plugin_page = LaterPay_Helper_View::$pluginPage;
+        if( get_option( 'laterpay_plugin_is_in_live_mode' ) ) {
+            $plugin_page = LaterPay_Helper_View::$pluginPage;
+        } else {
+            $plugin_page = 'laterpay-account-tab';
+        }
         add_menu_page(
             __( 'LaterPay Plugin Settings', 'laterpay' ),
             'LaterPay',

--- a/laterpay/asset_sources/scss/pages/_post_edit.scss
+++ b/laterpay/asset_sources/scss/pages/_post_edit.scss
@@ -219,3 +219,58 @@
     display: block;
     margin: $fs 0;
 }
+
+
+// plugin mode indicator -----------------------------------------------------------------------------------------------
+.lp_plugin-mode-indicator {
+    position: relative;
+    //right: $fs * 7; // leave sufficient space for contextual help link
+    top: $fs--25 - $fs--015;
+
+    // LaterPay logo (rendered in pseudo element from icon font)
+    &:before {
+        float: left;
+        font-size: $fs--3;
+        //left: -2.75rem;
+        line-height: 0;
+        position: relative;
+        top: $fs--2;
+    }
+
+    .lp_plugin-mode-indicator__title {
+        color: $clickable;
+        font-size: $fs !important;
+        margin: $fs 0 $fs--05 !important;
+        position: relative;
+        left: $fs--2;
+        top: -$fs--3;
+    }
+
+    &:active,
+    &:focus,
+    &:hover {
+
+        &:before,
+        .lp_plugin-mode-indicator__title,
+        i {
+            color: $clickable--highlight;
+        }
+    }
+
+    i {
+        color: $clickable;
+        font-style: normal;
+    }
+
+    .lp_plugin-mode-indicator__text {
+        color: $text--lighter;
+        position: relative;
+        left: $fs--2;
+        top: -$fs--4;
+    }
+}
+
+// add red color icon for
+.account_setup_warning[data-icon]:before {
+    color: red;
+}

--- a/laterpay/views/backend/partials/post-pricing-form.php
+++ b/laterpay/views/backend/partials/post-pricing-form.php
@@ -11,6 +11,32 @@ if ( ! defined( 'ABSPATH' ) ) {
     lpVars.limits = <?php echo wp_json_encode( $laterpay['price_ranges'] ); ?>;
 </script>
 <div class="lp_clearfix">
+    <div class="lp_tooltip" data-tooltip="<?php echo esc_attr( __( 'Click here to finish your account set up', 'laterpay' ) ); ?>">
+        <?php if ( ! $laterpay['plugin_is_in_live_mode'] ) : ?>
+            <a href="<?php echo esc_url( add_query_arg( array( 'page' => 'laterpay-account-tab' ), admin_url( 'admin.php' ) ) ); ?>"
+               class="lp_plugin-mode-indicator"
+               data-icon="h">
+                <h2 class="lp_plugin-mode-indicator__title"><?php esc_html_e( 'Test mode', 'laterpay' ); ?></h2>
+                <span class="lp_plugin-mode-indicator__text">
+                    <?php
+                    /* translators: %1$s info text1, %2$s info text2*/
+                    printf( '%1$s<i> %2$s</i>', esc_html__( 'Earn money in', 'laterpay' ), esc_html__( 'live mode', 'laterpay' ) );
+                    ?>
+                </span>
+            </a>
+        <?php endif; ?>
+    </div>
+    <?php if( get_option( 'laterpay_is_in_visible_test_mode' ) ): ?>
+    <p class="account_setup_warning" data-icon="n">
+        <?php
+        printf( '%1s <a href="%2$s">%3$s</a> %4$s',
+            esc_html__( 'Your LaterPay Plugin is currently invisible to viewers. Click', 'laterpay' ),
+            esc_url( add_query_arg( array( 'page' => 'laterpay-account-tab' ), admin_url( 'admin.php' ) ) ),
+            esc_html__( 'here', 'laterpay' ),
+            esc_html__( 'to toggle visibility.', 'laterpay' ) );
+        ?>
+    </p>
+    <?php endif; ?>
     <div class="lp_layout lp_mt+ lp_mb+">
         <div id="lp_js_postPriceRevenueModel" class="lp_layout__item lp_3/8">
             <label class="lp_badge lp_badge--revenue-model lp_tooltip


### PR DESCRIPTION
Fixes #946 

>Add info messages if account setup is not done.
>Set default tab as Account until setup is not complete.

Screenshot

![screenshot 2](https://user-images.githubusercontent.com/13589980/45011042-24f7bd80-b02e-11e8-91a2-c220ac1f43f3.jpeg)