### PR TITLE
Enable all default editor configuration in teaser metabox

### DIFF
--- a/laterpay/application/Controller/Admin/Post/Metabox.php
+++ b/laterpay/application/Controller/Admin/Post/Metabox.php
@@ -218,7 +218,6 @@ class LaterPay_Controller_Admin_Post_Metabox extends LaterPay_Controller_Base
             'tabindex'        => null,
             'editor_css'      => '',
             'editor_class'    => '',
-            'teeny'           => 1,
             'dfw'             => 1,
             'tinymce'         => 1,
             'quicktags'       => 1,


### PR DESCRIPTION
Fixes https://github.com/laterpay/laterpay-wordpress-plugin/issues/996