### PR TITLE
Fix issue with duplicate queries

### DIFF
--- a/laterpay/application/Model/SubscriptionWP.php
+++ b/laterpay/application/Model/SubscriptionWP.php
@@ -24,6 +24,15 @@ class LaterPay_Model_SubscriptionWP {
     private static $term_data_store = [];
 
     /**
+     * Store hash of query and data for duplicate queries for subscriptions.
+     *
+     * @var array Internal Cache for Duplicate Queries.
+     *
+     * @access private
+     */
+    private static $subscription_data_store = [];
+
+    /**
      * Constructor for class LaterPay_Model_SubscriptionWP,
      * Kept private as class is singleton.
      */
@@ -287,13 +296,31 @@ class LaterPay_Model_SubscriptionWP {
             $query_args['post_status'] = 'publish';
         }
 
-        $get_subscription_query = new WP_Query( $query_args );
+        // Create a hash from the query args.
+        $args_hash = md5( wp_json_encode( $query_args ) );
 
-        $posts         = $get_subscription_query->get_posts();
-        $subscriptions = [];
+        // Check if data already exists for requested query args.
+        if ( isset( self::$subscription_data_store[ $args_hash ] ) ) {
 
-        foreach ( $posts as $key => $post ) {
-            $subscriptions[ $key ] = $this->transform_post_to_subscription( $post );
+            // Get data from internal cache for already requested query.
+            $subscriptions = self::$subscription_data_store[ $args_hash ];
+
+        } else {
+
+            // Initialize WP_Query without args.
+            $get_subscriptions_in_category_query = new WP_Query();
+
+            // Get posts for requested args.
+            $posts         = $get_subscriptions_in_category_query->query( $query_args );
+            $subscriptions = [];
+
+            foreach ( $posts as $key => $post ) {
+                $subscriptions[ $key ] = $this->transform_post_to_subscription( $post );
+            }
+
+            // Store formatted data, in case same query is fired again.
+            self::$subscription_data_store[ $args_hash ] = $subscriptions;
+
         }
 
         LaterPay_Hooks::get_instance()->add_wp_query_hooks();

--- a/laterpay/application/Model/TimePassWP.php
+++ b/laterpay/application/Model/TimePassWP.php
@@ -32,6 +32,15 @@ class LaterPay_Model_TimePassWP {
     private static $term_data_store = [];
 
     /**
+     * Store hash of query and data for duplicate queries for time passes.
+     *
+     * @var array Internal Cache for Duplicate Queries.
+     *
+     * @access private
+     */
+    private static $time_pass_data_store = [];
+
+    /**
      * Blank constructor to avoid creation of new instances.
      *
      * LaterPay_Model_TimePassWP constructor.
@@ -133,9 +142,29 @@ class LaterPay_Model_TimePassWP {
             $args['post_status'] = array( 'publish', 'draft' );
         }
 
-        $query = new WP_Query( $args );
+        // Create a hash from the query args.
+        $args_hash = md5( wp_json_encode( $args ) );
 
-        $result = $this->get_formatted_results( $query->get_posts() );
+        // Check if data already exists for requested query args.
+        if ( isset( self::$time_pass_data_store[ $args_hash ] ) ) {
+
+            // Get data from internal cache for already requested query.
+            $result = self::$time_pass_data_store[ $args_hash ];
+
+        } else {
+
+            // Initialize WP_Query without args.
+            $query = new WP_Query();
+
+            // Get posts for requested args.
+            $posts = $query->query( $args );
+
+            // Get formatted data and store it, in case same query is fired again.
+            $result = $this->get_formatted_results( $posts );
+
+            self::$time_pass_data_store[ $args_hash ] = $result;
+
+        }
 
         // Add removed WP_Query hooks.
         LaterPay_Hooks::get_instance()->add_wp_query_hooks();


### PR DESCRIPTION
Remove call of get_posts when not needed
Add internal cache option to store data for duplicate queries.