### PR TITLE
Revert "Remove  Individual article with price zero from purchase options"

### DIFF
--- a/laterpay/application/Controller/Install.php
+++ b/laterpay/application/Controller/Install.php
@@ -535,7 +535,7 @@ class LaterPay_Controller_Install extends LaterPay_Controller_Base
             }
 
             delete_option( 'laterpay_only_time_pass_purchases_allowed' );
-        } elseif ( false === get_option( 'laterpay_post_price_behaviour' ) && version_compare( $current_version, '2.6.3', '>' ) ) {
+        } else if ( false === get_option( 'laterpay_post_price_behaviour' ) && version_compare( $current_version, '2.6.3', '>' ) ) {
             update_option( 'laterpay_post_price_behaviour', 0 );
         }
     }

--- a/laterpay/application/Helper/Pricing.php
+++ b/laterpay/application/Helper/Pricing.php
@@ -90,7 +90,7 @@ class LaterPay_Helper_Pricing
 
             $is_global_price_type = LaterPay_Helper_Pricing::is_price_type_global( $post_price_type );
 
-            if ( empty( $post_price_type ) || $is_global_price_type || ( $is_price_zero && $is_time_pass_subscription_count_zero ) ) {
+            if ( empty( $post_price_type ) || $is_global_price_type ) {
                 return null;
             }
         } elseif ( $post_price_type_one ) {
@@ -99,7 +99,8 @@ class LaterPay_Helper_Pricing
                 return null;
             }
         } elseif ( 2 === $post_price_behaviour ) {
-            if ( ( $is_price_zero && $is_time_pass_subscription_count_zero ) || $is_post_type_not_supported ) {
+            if ( ( $is_price_zero && self::is_post_price_type_two_price_zero()
+                   && $is_time_pass_subscription_count_zero ) || $is_post_type_not_supported ) {
                 // returns null for this case
                 return null;
             }

--- a/laterpay/application/Module/Purchase.php
+++ b/laterpay/application/Module/Purchase.php
@@ -681,10 +681,8 @@ class LaterPay_Module_Purchase extends LaterPay_Core_View implements LaterPay_Co
 
             // Add article to combined purchase options.
             if ( ! empty( $article_individual_price ) ) {
-                if ( floatval( 0.00 ) !== floatval( $article_individual_price['actual_price'] ) ) {
-                    $article_individual_price['type'] = 'article';
-                    $final_purchase_options[]         = $article_individual_price;
-                }
+                $article_individual_price['type'] = 'article';
+                $final_purchase_options[]         = $article_individual_price;
             }
 
             // Add time pass to combined purchase options.


### PR DESCRIPTION
Reverts laterpay/laterpay-wordpress-plugin#1309

This is being done so that conditions match as mentioned in https://github.com/laterpay/laterpay-wordpress-plugin/issues/977#issuecomment-425946174 