### PR TITLE
Temporarily lock node version for project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,24 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Lock Node.js to v11.10.1 to play nice with gulp"
+          command: |
+            curl -sSL "https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v11.10.1-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | sudo bash
+
+      - run:
           name: Install NPM & GULP
           command: |
                 sudo npm install -g npm@latest
                 sudo npm install -g gulp
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
+      # rebuild node-sass to avoid environment binding changes.
       - run:
           name: RUN NPM INSTALL IN PROJECT
-          command: npm install
+          command: |
+            npm install
+            npm rebuild node-sass
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:


### PR DESCRIPTION
- Fixes deployment issue on CirceCI
- Uses olde node version to work with `gulp`
