### PR TITLE
Add release notice for v2.8.0

### DIFF
--- a/laterpay/application/Controller/Admin.php
+++ b/laterpay/application/Controller/Admin.php
@@ -903,7 +903,7 @@ class LaterPay_Controller_Admin extends LaterPay_Controller_Base
             if ( ! empty( $ga_data['update_highlights']['version'] ) ) {
                 $version_update_number                   = $ga_data['update_highlights']['version'];
                 $ga_data['update_highlights']['version'] = sprintf( esc_html__( 'Version %s Highlights:', 'laterpay' ), $version_update_number );
-                $ga_data['update_highlights']['notice']  = sprintf( esc_html__( 'At long last, one of our most highly requested features is here! Check out the new Contributions tab to explore our newest feature.', 'laterpay' ) );
+                $ga_data['update_highlights']['notice']  = esc_html__( 'Try the all new LaterPay Blocks now in your WordPress Post or Page editor!', 'laterpay' );
                 $ga_data['update_highlights_nonce']      = wp_create_nonce( 'update_highlights_nonce' );
             }
 

--- a/laterpay/application/Controller/Install.php
+++ b/laterpay/application/Controller/Install.php
@@ -686,7 +686,7 @@ class LaterPay_Controller_Install extends LaterPay_Controller_Base
         if ( ! empty( $current_version ) ) {
 
             $update_highlights = [
-                'version' => '2.7.0',
+                'version' => '2.8.0',
             ];
 
             update_option( 'lp_update_highlights', $update_highlights );

--- a/laterpay/laterpay.php
+++ b/laterpay/laterpay.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/laterpay/laterpay-wordpress-plugin
  * Description: Sell digital content with LaterPay. It allows super easy and fast payments from as little as 5 cent up to 149.99 Euro at a 15% fee and no fixed costs.
  * Author: LaterPay GmbH
- * Version: 2.8.0
+ * Version: 2.7.0
  * Author URI: https://laterpay.net/
  * Textdomain: laterpay
  * Domain Path: /languages

--- a/laterpay/laterpay.php
+++ b/laterpay/laterpay.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/laterpay/laterpay-wordpress-plugin
  * Description: Sell digital content with LaterPay. It allows super easy and fast payments from as little as 5 cent up to 149.99 Euro at a 15% fee and no fixed costs.
  * Author: LaterPay GmbH
- * Version: 2.7.0
+ * Version: 2.8.0
  * Author URI: https://laterpay.net/
  * Textdomain: laterpay
  * Domain Path: /languages


### PR DESCRIPTION
For https://github.com/laterpay/laterpay-wordpress-plugin/issues/1329

PR contains following changes.
<img width="1679" alt="issue-1329" src="https://user-images.githubusercontent.com/8168027/69319299-ed8e2480-0c64-11ea-804d-b00c9934c020.png">
