### PR TITLE
Allow merchant to clear selected media, add filename along with preview

### DIFF
--- a/laterpay/application/Controller/Admin/TinyMCE.php
+++ b/laterpay/application/Controller/Admin/TinyMCE.php
@@ -121,10 +121,17 @@ class LaterPay_Controller_Admin_TinyMCE extends LaterPay_Controller_Admin_Base {
             'laterpay_shortcode_generator_labels',
             array(
                 'button'                       => array(
-                    'text' => esc_html__( 'LaterPay ShortCodes', 'laterpay' ),
+                    'text'  => esc_html__( 'LaterPay ShortCodes', 'laterpay' ),
+                    'clear' => esc_html__( 'Clear', 'laterpay' ),
                 ),
-                'preview_image'                => sprintf( '%spremium-text.png', $this->config->image_url ),
-                'no_preview_image'             => sprintf( '%sno-preview.png', $this->config->image_url ),
+                'preview_images'               => array(
+                    'text'             => sprintf( '%spremium-text.png', $this->config->image_url ),
+                    'audio'            => sprintf( '%spremium-audio.png', $this->config->image_url ),
+                    'download'         => sprintf( '%spremium-download.png', $this->config->image_url ),
+                    'gallery'          => sprintf( '%spremium-gallery.png', $this->config->image_url ),
+                    'video'            => sprintf( '%spremium-video.png', $this->config->image_url ),
+                    'no_preview_image' => sprintf( '%sno-preview.png', $this->config->image_url ),
+                ),
                 'premium_download'             => array(
                     'title'             => esc_html__( 'LaterPay Premium Download Box', 'laterpay' ),
                     'target_post_id'    => array(

--- a/laterpay/asset_sources/scss/laterpay-admin.scss
+++ b/laterpay/asset_sources/scss/laterpay-admin.scss
@@ -55,3 +55,28 @@ dfn.lp_region_notice {
 .lp_wpengn_nbtn:link,.lp_wpengn_nbtn:hover,.lp_wpengn_nbtn:hover {
   color:#fff;
 }
+
+
+.mce-container {
+    .lp-media-preview {
+        padding: 10px;
+
+        .preview-image {
+            height: 100px;
+            width: 100px;
+            margin-right: 10px;
+            display: block;
+            float: left;
+        }
+
+        .media-name {
+            display: block;
+            overflow: hidden;
+            white-space: pre-wrap;
+            margin-bottom: 10px;
+            text-overflow: ellipsis;
+            cursor: pointer;
+        }
+    }
+
+}


### PR DESCRIPTION
- Allow merchant to clear selected media
- Add filename along with preview for clarity in shortcode generator

For https://github.com/laterpay/laterpay-wordpress-plugin/issues/1343
and https://github.com/laterpay/laterpay-wordpress-plugin/issues/1344