### PR TITLE
Remove repeated call to `validatesignature` endpoint

### DIFF
--- a/laterpay/application/Controller/Admin/Account.php
+++ b/laterpay/application/Controller/Admin/Account.php
@@ -512,32 +512,4 @@ class LaterPay_Controller_Admin_Account extends LaterPay_Controller_Admin_Base {
 
         return $client;
     }
-
-    /**
-     * Get a client instance based on current region and set plugin mode to test.
-     */
-    public static function validate_current_credentials() {
-
-        // Get current client options, and new client instance.
-        $client_options = LaterPay_Helper_Config::get_php_client_options();
-        $client         = new LaterPay_Client(
-            $client_options['cp_key'],
-            $client_options['api_key'],
-            $client_options['api_root'],
-            $client_options['web_root'],
-            $client_options['token_name']
-        );
-
-        // Check if current config is valid or not.
-        $response = json_decode( $client->check_health( true ), true );
-
-        // Change plugin mode to test.
-        if ( false === $response['is_valid'] ) {
-            update_option( 'laterpay_plugin_is_in_live_mode', '0' );
-            return false;
-        }
-
-        return true;
-    }
-
 }

--- a/laterpay/application/Controller/Frontend/Post.php
+++ b/laterpay/application/Controller/Frontend/Post.php
@@ -16,7 +16,6 @@ class LaterPay_Controller_Frontend_Post extends LaterPay_Controller_Base
         return array(
             'laterpay_post_content' => array(
                 array( 'laterpay_on_plugin_is_working', 250 ),
-                array( 'laterpay_on_valid_account_credential', 200 ),
                 array( 'modify_post_content' ),
             ),
             'laterpay_posts' => array(

--- a/laterpay/application/Module/Appearance.php
+++ b/laterpay/application/Module/Appearance.php
@@ -34,9 +34,6 @@ class LaterPay_Module_Appearance extends LaterPay_Core_View implements LaterPay_
             'laterpay_on_enabled_post_type' => array(
                 array( 'on_enabled_post_type' ),
             ),
-            'laterpay_on_valid_account_credential' => array(
-                array( 'on_valid_account_credential' ),
-            ),
             'laterpay_on_ajax_user_can_activate_plugins' => array(
                 array( 'on_ajax_user_can_activate_plugins' ),
             ),
@@ -173,17 +170,6 @@ class LaterPay_Module_Appearance extends LaterPay_Core_View implements LaterPay_
         }
         $is_enabled_post_type = in_array( $post->post_type, $this->config->get( 'content.enabled_post_types' ), true );
         if ( ! $is_enabled_post_type  ) {
-            $event->stop_propagation();
-        }
-    }
-
-    /**
-     * Stops bubbling if account credentials are not valid.
-     *
-     * @param LaterPay_Core_Event $event
-     */
-    public function on_valid_account_credential( LaterPay_Core_Event $event ) {
-        if ( true === (bool) get_option( 'laterpay_plugin_is_in_live_mode' ) && ! LaterPay_Controller_Admin_Account::validate_current_credentials() ) {
             $event->stop_propagation();
         }
     }

--- a/laterpay/application/Module/Purchase.php
+++ b/laterpay/application/Module/Purchase.php
@@ -64,7 +64,6 @@ class LaterPay_Module_Purchase extends LaterPay_Core_View implements LaterPay_Co
             'laterpay_post_content' => array(
                 array( 'laterpay_on_view_purchased_post_as_visitor', 200 ),
                 array( 'is_purchasable', 100 ),
-                array( 'laterpay_on_valid_account_credential', 100 ),
                 array( 'modify_post_content', 5 ),
             ),
             'laterpay_check_user_access' => array(

--- a/laterpay/application/Module/TimePasses.php
+++ b/laterpay/application/Module/TimePasses.php
@@ -22,7 +22,6 @@ class LaterPay_Module_TimePasses extends LaterPay_Core_View implements LaterPay_
     public static function get_subscribed_events() {
         return array(
             'laterpay_post_content' => array(
-                array( 'laterpay_on_valid_account_credential', 100 ),
                 array( 'modify_post_content', 5 ),
             ),
             'laterpay_time_passes' => array(


### PR DESCRIPTION
For https://github.com/laterpay/laterpay-wordpress-plugin/issues/1382

- Remove repeated call to `validatesignature` endpoint
- Revert to test mode if invalid response is received in health check