### PR TITLE
[GH-1398]: Fix parsing of numeric input values when generating Contributions shortcode.

### DIFF
--- a/laterpay/asset_sources/js/laterpay-backend-contributions.js
+++ b/laterpay/asset_sources/js/laterpay-backend-contributions.js
@@ -223,7 +223,10 @@
                                 $($o.revenueModelMultipleItems).each(function (idx) {
                                     var inputId = idx + 1;
                                     var $inputElement = $('#lp_multiple_contribution_input_' + inputId);
-                                    var price = $inputElement.val().length ? $inputElement.val() : 0.00;
+
+                                    var price = parseInt( $inputElement.val(), 10 );
+                                    price     = price.toFixed( 2 );
+
                                     var revenueModel = $('#post_price_revenue_model_' + inputId)
                                         .find('input:checked').val();
 
@@ -235,7 +238,7 @@
                                     }
 
                                     // Only add if price is greater than 0.00
-                                    if (parseFloat(price) > 0.00) {
+                                    if (0.00 < price) {
                                         var priceInfo = {
                                             price      : price * 100,
                                             revenue    : revenueModel,


### PR DESCRIPTION
This PR is about fixing an issue with NaN returned after multiply operation.

When generating Contribution, JS goes through each input and runs `parseFloat` check on the value. This is incorrect since it allows '2,00' value to pass the `parseFloat( '2,00' ) > 0.00` check and then multiplying this string by 100 – e.g. `('2,00' * 100)` – without type casting results in NaN and incorrect value in a shortcode.

In this fix, the input value is parsed as integer and then converted to float using `toFixed( 2 )`. This ensures that the check is correct and multiply operation will return expected value.

Ref: https://github.com/laterpay/laterpay-wordpress-plugin/issues/1398