### PR TITLE
CT-1036: Bump "Tested up to" version to 5.6

### DIFF
--- a/laterpay/README.txt
+++ b/laterpay/README.txt
@@ -4,7 +4,7 @@ Contributors: laterpay, dominik-rodler, mihail-turalenka, avahura, ahryb
 Donate link: https://laterpay.net
 Tags: contribution, micropayment, paywall, sell content, subscription, conversion, earn money, monetization, monetize content, paid content, payment, sell article
 Requires at least: 4.6
-Tested up to: 5.5
+Tested up to: 5.6
 Requires PHP: 5.6
 Stable tag: 2.9.7
 Author URI: https://laterpay.net


### PR DESCRIPTION
WordPress 5.6 will be out next week and we tested the plugin running the release candidate version. Everything looked good, so we're just updating "Tested up to" version in WordPress plugin repository.

Ref: https://laterpay.atlassian.net/browse/CT-1036